### PR TITLE
OpenAI Client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,5 @@ Style/Documentation:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+RSpec/ExampleLength:
+  Max: 10

--- a/lib/services/open_ai_client.rb
+++ b/lib/services/open_ai_client.rb
@@ -1,0 +1,54 @@
+require 'openai'
+require_relative 'service'
+
+class OpenAIClient < Service
+  option :message, type: Dry::Types['strict.string']
+
+  Schema = Dry::Schema.Params do
+    required(:message).filled
+  end
+
+  def call
+    Success.new(send_message_and_parse_response)
+  rescue StandardError => e
+    log_with_failure(e.message)
+  end
+
+  private
+
+  def client
+    @client ||= OpenAI::Client.new(access_token: openai_api_key)
+  end
+
+  def messages
+    [{ role: 'user', content: @message }]
+  end
+
+  def model
+    @model ||= ENV.fetch('OPENAI_MODEL', 'gpt-3.5-turbo')
+  end
+
+  def openai_api_key
+    @openai_api_key ||= ENV.fetch('OPENAI_API_KEY', 'api_key')
+  end
+
+  def parameters
+    {
+      messages:, model:, temperature:
+    }
+  end
+
+  def parse_response(response)
+    logger.debug(response)
+    response.dig('choices', 0, 'message', 'content')
+  end
+
+  def send_message_and_parse_response
+    response = client.chat(parameters:)
+    parse_response(response)
+  end
+
+  def temperature
+    @temperature ||= ENV.fetch('OPENAI_TEMPERATURE', 0.7)
+  end
+end

--- a/spec/lib/services/open_ai_client_spec.rb
+++ b/spec/lib/services/open_ai_client_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require_relative '../../../lib/services/open_ai_client'
+
+RSpec.describe(OpenAIClient) do
+  describe('#call') do
+    it 'returns a success monad' do
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return({ 'choices' => [] })
+
+      response = described_class.call(message: 'tell a joke')
+
+      expect(response.success?).to be(true)
+    end
+
+    it 'returns a response based on provided string' do
+      content = { 'content' => 'Why did the tomato turn red? Because it saw the salad dressing!' }
+      message = { 'message' => content }
+
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return({ 'choices' => [message] })
+
+      response = described_class.call(message: 'tell a joke')
+
+      expect(response.value!).to include('Why did the tomato turn red?')
+    end
+
+    it 'logs the response from OpenAI when DEBUG is set' do
+      ENV['DEBUG'] = 'true'
+      mock_logger = double
+
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return({ 'choices' => [] })
+      allow(TTY::Logger).to receive(:new).and_return(mock_logger)
+
+      expect(mock_logger).to receive(:debug).with({ 'choices' => [] })
+
+      described_class.call(message: 'tell a joke')
+
+      ENV['DEBUG'] = nil
+    end
+
+    context('when OpenAI::Client raises an error') do
+      it 'returns a failure monad' do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(StandardError)
+
+        response = described_class.call(message: 'tell a joke')
+
+        expect(response.success?).to be(false)
+      end
+
+      it 'logs an error message' do
+        mock_logger = double
+
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(StandardError)
+        allow(TTY::Logger).to receive(:new).and_return(mock_logger)
+
+        expect(mock_logger).to receive(:error).with('[OpenAIClient] - StandardError')
+
+        described_class.call(message: 'tell a joke')
+      end
+    end
+
+    context('when the requirement is not provided') do
+      it 'returns a failure monad' do
+        response = described_class.call(message: false)
+
+        expect(response.success?).to be(false)
+      end
+
+      it 'logs an error message' do
+        mock_logger = double
+
+        allow(TTY::Logger).to receive(:new).and_return(mock_logger)
+
+        expect(mock_logger).to receive(:fatal).with('false violates constraints (type?(String, false) failed)')
+
+        described_class.call(message: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a service object that uses `ruby-openai`'s `OpenAI::Client` to make calls to ChatGPT with sane defaults.