### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: Tests and Linting
 
 on:
   push:
@@ -12,17 +12,29 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['3.1']
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby
+
+    - name: Install Ruby (3.1.x)
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: 3.1
         bundler-cache: true
-    - name: Run linter
+
+    - name: Setup Code Climate test-reporter
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+        ./cc-test-reporter before-build
+
+    - name: Run StandardRB
       run: bundle exec standardrb
-    - name: Run tests
+
+    - name: Run tests with RSpec
       run: bundle exec rspec
+
+    - name: Publish code coverage to Code Climate
+      run: |
+        export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+        ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run linter
+      run: bundle exec standardrb
+    - name: Run tests
+      run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   dry-core (~> 1.0.0)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Autobot GPT
+[![Maintainability](https://api.codeclimate.com/v1/badges/0be3a49ca599e9699ea7/maintainability)](https://codeclimate.com/github/jeffdevine/autobot-gpt/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/0be3a49ca599e9699ea7/test_coverage)](https://codeclimate.com/github/jeffdevine/autobot-gpt/test_coverage)
 
 Autobot GPT is a ruby port of Adam McMurchie's [Automator](https://github.com/murchie85/GPT_AUTOMATE). Automator uses OpenAI's GPT models to decompose software requests into small deliverables and generate code for each.
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/0be3a49ca599e9699ea7/maintainability)](https://codeclimate.com/github/jeffdevine/autobot-gpt/maintainability)
-
-# What can Autobot do?
+## What can Autobot do?
 It is early days, and it currently mimics the functionality of [Automator](https://github.com/murchie85/GPT_AUTOMATE). `Autobot` will ask you to describe your requirements and determine if it can use [OpenAI](https://openai.com) models to write software for your request.
 
-## Environment Setup
+# Environment Setup
 
-**OS X**
+## macOS
+
 To install everything locally, you'll need the following:
 
 * Ruby 3.1.x
 * OpenAPI API Key
 
-# Ruby
+### Ruby
 You can install and manage your rubies using any tool you want. The following describes how to manage it with [Homebrew](https://brew.sh) and [asdf](https://asdf-vm.com).
 
 First, install [Homebrew](https://brew.sh):
@@ -54,7 +54,7 @@ Run `bundle` to install the required gems:
 bundle install
 ```
 
-## Development Tools
+### Development Tools
 To run the test suite, execute:
 
 ```


### PR DESCRIPTION
Adds GitHub actions to:

- Lint code via https://github.com/standardrb/standard
- Run `rspec` tests
- Report coverage results to https://codeclimate.com